### PR TITLE
Initial JARVIS GUI assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # JARVIS-V.2
+
+A minimal voice assistant reminiscent of JARVIS from the Iron Man films. The project provides a simple GUI application using Tkinter along with speech recognition and speech synthesis.
+
+## Requirements
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+The assistant uses the default system microphone and speakers.
+
+## Usage
+
+Run the main application:
+
+```bash
+python main.py
+```
+
+Click **Start** to begin listening. Say "shutdown" to stop the assistant.
+
+## License
+
+This project is licensed under the MIT License.

--- a/jarvis/__init__.py
+++ b/jarvis/__init__.py
@@ -1,0 +1,6 @@
+"""JARVIS assistant package."""
+
+from .core import JarvisCore
+from .gui import JarvisGUI
+
+__all__ = ["JarvisCore", "JarvisGUI"]

--- a/jarvis/core.py
+++ b/jarvis/core.py
@@ -1,0 +1,49 @@
+import speech_recognition as sr
+import pyttsx3
+from threading import Thread
+
+class JarvisCore:
+    """Core functionality for the JARVIS assistant."""
+
+    def __init__(self):
+        self.recognizer = sr.Recognizer()
+        self.tts_engine = pyttsx3.init()
+        self.listening = False
+
+    def _speak(self, text: str):
+        """Speak text using text-to-speech."""
+        self.tts_engine.say(text)
+        self.tts_engine.runAndWait()
+
+    def listen(self):
+        """Continuously listen for voice commands."""
+        self.listening = True
+        self._speak("How may I assist you?")
+        while self.listening:
+            try:
+                with sr.Microphone() as source:
+                    audio = self.recognizer.listen(source)
+                command = self.recognizer.recognize_google(audio)
+                self._handle_command(command)
+            except sr.UnknownValueError:
+                self._speak("I beg your pardon, sir, I did not catch that.")
+            except Exception as exc:
+                self._speak(f"An error occurred: {exc}")
+                self.listening = False
+
+    def stop_listening(self):
+        self.listening = False
+
+    def _handle_command(self, command: str):
+        """Process a recognized voice command."""
+        command = command.lower()
+        if "shutdown" in command:
+            self._speak("Shutting down. Goodbye, sir.")
+            self.stop_listening()
+        else:
+            self._speak(f"You said: {command}")
+
+    def start(self):
+        thread = Thread(target=self.listen, daemon=True)
+        thread.start()
+        return thread

--- a/jarvis/gui.py
+++ b/jarvis/gui.py
@@ -1,0 +1,28 @@
+import tkinter as tk
+from tkinter import messagebox
+from .core import JarvisCore
+
+class JarvisGUI(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("JARVIS Assistant")
+        self.geometry("300x150")
+
+        self.core = JarvisCore()
+
+        self.start_button = tk.Button(self, text="Start", command=self.start_listening)
+        self.start_button.pack(pady=10)
+
+        self.stop_button = tk.Button(self, text="Stop", command=self.stop_listening, state=tk.DISABLED)
+        self.stop_button.pack(pady=10)
+
+    def start_listening(self):
+        self.core.start()
+        self.start_button.config(state=tk.DISABLED)
+        self.stop_button.config(state=tk.NORMAL)
+
+    def stop_listening(self):
+        self.core.stop_listening()
+        self.start_button.config(state=tk.NORMAL)
+        self.stop_button.config(state=tk.DISABLED)
+        messagebox.showinfo("JARVIS", "Assistant stopped.")

--- a/main.py
+++ b/main.py
@@ -1,0 +1,10 @@
+from jarvis.gui import JarvisGUI
+
+
+def main():
+    app = JarvisGUI()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyttsx3
+SpeechRecognition


### PR DESCRIPTION
## Summary
- implement basic JarvisCore with voice recognition and speech synthesis
- add simple Tkinter GUI
- create main entrypoint
- add package init and requirements
- document setup and usage

## Testing
- `python -m py_compile jarvis/*.py main.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_686126a10a1483289d4952b18ada4036