### PR TITLE
Add config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install -r requirements.txt
 
 The assistant uses the default system microphone and speakers.
 
-Set the `OPENAI_API_KEY` environment variable with your OpenAI API key to enable ChatGPT responses.
+Configuration values such as `OPENAI_API_KEY` can be placed in `config.json` in the project root. The assistant will fall back to environment variables if the file is absent or keys are missing.
 
 Optionally place `loading.gif` and `background.gif` in `jarvis/assets/` to customize the loading screen and animated background. If these files are not present the GUI falls back to simple colors.
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+  "OPENAI_API_KEY": "",
+  "MODEL": "gpt-3.5-turbo"
+}


### PR DESCRIPTION
## Summary
- add a simple `config.json` for API keys and options
- load settings from the config in `JarvisCore`
- fall back to environment variables when keys are absent
- document the new configuration file

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68616485f848832897fc0978e6e53822