### PR TITLE
Refine core interface and real-time logging

### DIFF
--- a/jarvis/core.py
+++ b/jarvis/core.py
@@ -50,6 +50,10 @@ class JarvisCore:
     def stop_listening(self):
         self.listening = False
 
+    def stop(self):
+        """Stop the assistant via the public interface."""
+        self.stop_listening()
+
     def _handle_command(self, command: str):
         """Process a recognized voice command."""
         command = command.lower()
@@ -60,7 +64,7 @@ class JarvisCore:
             if self.log_callback:
                 self.log_callback(f"JARVIS: {reply}")
             self._speak(reply)
-            self.stop_listening()
+            self.stop()
         else:
             response = self._chatgpt_response(command)
             if self.log_callback:

--- a/jarvis/gui.py
+++ b/jarvis/gui.py
@@ -57,21 +57,28 @@ class JarvisGUI(tk.Tk):
         self.stop_button.pack(side=tk.LEFT, padx=5)
 
     def log_message(self, message: str):
-        """Append a message to the log view."""
+        """Append a message to the log view in a thread-safe way."""
         if not self.log_text:
             return
-        self.log_text.config(state=tk.NORMAL)
-        self.log_text.insert(tk.END, message + "\n")
-        self.log_text.see(tk.END)
-        self.log_text.config(state=tk.DISABLED)
+
+        def append():
+            self.log_text.config(state=tk.NORMAL)
+            self.log_text.insert(tk.END, message + "\n")
+            self.log_text.see(tk.END)
+            self.log_text.config(state=tk.DISABLED)
+
+        # Ensure updates from background threads do not interfere with Tkinter
+        self.after(0, append)
 
     def start_listening(self):
+        """Start the JARVIS core."""
         self.core.start()
         self.start_button.config(state=tk.DISABLED)
         self.stop_button.config(state=tk.NORMAL)
 
     def stop_listening(self):
-        self.core.stop_listening()
+        """Stop the JARVIS core."""
+        self.core.stop()
         self.start_button.config(state=tk.NORMAL)
         self.stop_button.config(state=tk.DISABLED)
         self.log_message("JARVIS: Assistant stopped.")


### PR DESCRIPTION
## Summary
- add `stop` method to `JarvisCore`
- update GUI to use `core.start()` and `core.stop()`
- ensure log updates are thread-safe for real-time display

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68616488d1008328bc0aeeee321866cc