### PR TITLE
Add ChatGPT module with retry fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Use the optional `-InstallPython` flag if Python 3 is not already installed.
 The assistant uses the default system microphone and speakers.
 
 Configuration values such as `OPENAI_API_KEY` can be placed in `config.json` in the project root. The assistant will fall back to environment variables if the file is absent or keys are missing.
+The `ChatGPTModule` wraps all OpenAI API calls and retries automatically on errors. Should the API be unreachable or the key missing, the assistant replies with a short apology instead of crashing.
 
 Optionally place `loading.gif` and `background.gif` in `jarvis/assets/` to customize the loading screen and animated background. If these files are not present the GUI falls back to simple colors.
 

--- a/jarvis/__init__.py
+++ b/jarvis/__init__.py
@@ -1,7 +1,7 @@
 """JARVIS assistant package."""
 
-from jarvis_core import JarvisCore
+from jarvis_core import JarvisCore, ChatGPTModule
 from .gui import JarvisGUI
 from .lab import LabModule
 
-__all__ = ["JarvisCore", "JarvisGUI", "LabModule"]
+__all__ = ["JarvisCore", "JarvisGUI", "LabModule", "ChatGPTModule"]

--- a/jarvis_core/__init__.py
+++ b/jarvis_core/__init__.py
@@ -1,5 +1,6 @@
 """Core package for the JARVIS assistant."""
 
 from .core import JarvisCore
+from .chatgpt import ChatGPTModule
 
-__all__ = ["JarvisCore"]
+__all__ = ["JarvisCore", "ChatGPTModule"]

--- a/jarvis_core/chatgpt.py
+++ b/jarvis_core/chatgpt.py
@@ -1,0 +1,52 @@
+import os
+import time
+import openai
+
+
+class ChatGPTModule:
+    """Handle ChatGPT API interactions with fallback behavior."""
+
+    def __init__(self, api_key: str | None = None, model: str = "gpt-3.5-turbo", log_callback=None) -> None:
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+        openai.api_key = self.api_key
+        self.model = model
+        self.log_callback = log_callback
+        self.conversation = [
+            {
+                "role": "system",
+                "content": (
+                    "You are JARVIS, an advanced AI assistant. Respond in a polite,"
+                    " concise manner."
+                ),
+            }
+        ]
+
+    def ask(self, prompt: str) -> str:
+        """Send a prompt to ChatGPT and return the reply."""
+        self.conversation.append({"role": "user", "content": prompt})
+        if not openai.api_key:
+            if self.log_callback:
+                self.log_callback("OPENAI_API_KEY not configured.")
+            reply = "Apologies, I'm currently unable to access my knowledge base."
+            self.conversation.append({"role": "assistant", "content": reply})
+            return reply
+
+        max_retries = 3
+        for attempt in range(1, max_retries + 1):
+            try:
+                response = openai.ChatCompletion.create(
+                    model=self.model, messages=self.conversation
+                )
+                reply = response.choices[0].message["content"].strip()
+                break
+            except Exception as exc:
+                if self.log_callback:
+                    self.log_callback(f"ChatGPT error (attempt {attempt}): {exc}")
+                if attempt == max_retries:
+                    reply = (
+                        "Apologies, I'm experiencing difficulties reaching my knowledge base."
+                    )
+                    break
+                time.sleep(1)
+        self.conversation.append({"role": "assistant", "content": reply})
+        return reply

--- a/jarvis_core/core.py
+++ b/jarvis_core/core.py
@@ -1,8 +1,8 @@
-import os
 import speech_recognition as sr
 import pyttsx3
-import openai
 from threading import Thread
+
+from .chatgpt import ChatGPTModule
 
 class JarvisCore:
     """Core functionality for the JARVIS assistant with ChatGPT integration."""
@@ -12,16 +12,8 @@ class JarvisCore:
         self.tts_engine = pyttsx3.init()
         self.listening = False
         self.log_callback = log_callback
-        openai.api_key = os.getenv("OPENAI_API_KEY")
-        self.conversation = [
-            {
-                "role": "system",
-                "content": (
-                    "You are JARVIS, an advanced AI assistant. Respond in a polite,"
-                    " concise manner."
-                ),
-            }
-        ]
+
+        self.chatgpt = ChatGPTModule(log_callback=log_callback)
 
     def _speak(self, text: str):
         """Speak text using text-to-speech."""
@@ -73,14 +65,5 @@ class JarvisCore:
         return thread
 
     def _chatgpt_response(self, prompt: str) -> str:
-        """Query the OpenAI ChatGPT API for a response."""
-        self.conversation.append({"role": "user", "content": prompt})
-        try:
-            response = openai.ChatCompletion.create(
-                model="gpt-3.5-turbo", messages=self.conversation
-            )
-            reply = response.choices[0].message["content"].strip()
-        except Exception as exc:
-            reply = f"I'm sorry, I encountered an error: {exc}"
-        self.conversation.append({"role": "assistant", "content": reply})
-        return reply
+        """Query the ChatGPT module for a response."""
+        return self.chatgpt.ask(prompt)


### PR DESCRIPTION
## Summary
- implement `ChatGPTModule` to manage ChatGPT API calls and retries
- integrate the module into `JarvisCore`
- re-export `ChatGPTModule` from `jarvis_core` and `jarvis`
- document the module and fallback behaviour in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68632515b28c83289c9a454439394e0e