### PR TITLE
Add unit tests and database module with CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,20 @@
+name: Python Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: pytest

--- a/jarvis_core/__init__.py
+++ b/jarvis_core/__init__.py
@@ -2,5 +2,12 @@
 
 from .core import JarvisCore
 from .chatgpt import ChatGPTModule
+from .database import init_db, insert_message, fetch_last_messages
 
-__all__ = ["JarvisCore", "ChatGPTModule"]
+__all__ = [
+    "JarvisCore",
+    "ChatGPTModule",
+    "init_db",
+    "insert_message",
+    "fetch_last_messages",
+]

--- a/jarvis_core/database.py
+++ b/jarvis_core/database.py
@@ -1,0 +1,48 @@
+import os
+import sqlite3
+from typing import List, Tuple
+
+DB_PATH = os.environ.get("JARVIS_DB_PATH", "jarvis.db")
+
+
+def init_db(db_path: str = DB_PATH) -> None:
+    """Initialize the database and create tables if necessary."""
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            role TEXT NOT NULL,
+            content TEXT NOT NULL
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def insert_message(role: str, content: str, db_path: str = DB_PATH) -> None:
+    """Insert a chat message into the history table."""
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO history (role, content) VALUES (?, ?)", (role, content)
+    )
+    conn.commit()
+    conn.close()
+
+
+def fetch_last_messages(limit: int = 10, db_path: str = DB_PATH) -> List[Tuple[str, str]]:
+    """Fetch the most recent chat messages."""
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT role, content FROM history ORDER BY id DESC LIMIT ?", (limit,)
+    )
+    rows = cur.fetchall()
+    conn.close()
+    return rows
+
+
+__all__ = ["init_db", "insert_message", "fetch_last_messages"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyttsx3
 SpeechRecognition
 openai
 PyQt5
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import os
+from PyQt5.QtWidgets import QApplication
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="session")
+def app():
+    """Provide a Qt application for tests."""
+    qt_app = QApplication.instance()
+    if qt_app is None:
+        qt_app = QApplication([])
+    return qt_app

--- a/tests/test_chatgpt.py
+++ b/tests/test_chatgpt.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import types
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import openai
+from jarvis_core.chatgpt import ChatGPTModule
+
+
+def test_ask_without_api_key(monkeypatch):
+    monkeypatch.setattr(openai, "api_key", None)
+    module = ChatGPTModule(api_key=None)
+    reply = module.ask("Hello?")
+    assert "Apologies" in reply
+    assert module.conversation[-1]["role"] == "assistant"
+
+
+def test_ask_with_api_key(monkeypatch):
+    module = ChatGPTModule(api_key="key")
+
+    class FakeResponse:
+        choices = [types.SimpleNamespace(message={"content": "Hello"})]
+
+    monkeypatch.setattr(
+        openai.ChatCompletion,
+        "create",
+        lambda model, messages: FakeResponse(),
+    )
+    reply = module.ask("Hi")
+    assert reply == "Hello"
+    assert module.conversation[-1]["content"] == "Hello"
+

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from jarvis_core import database
+
+
+def test_database_roundtrip(tmp_path):
+    db_file = tmp_path / "test.db"
+    database.init_db(db_path=str(db_file))
+    database.insert_message("user", "hello", db_path=str(db_file))
+    database.insert_message("assistant", "hi", db_path=str(db_file))
+    rows = database.fetch_last_messages(2, db_path=str(db_file))
+    assert rows[0] == ("assistant", "hi")
+    assert rows[1] == ("user", "hello")
+

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import json
+import types
+from io import StringIO
+from urllib import request
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt5.QtWidgets import QMessageBox
+
+from jarvis.lab import LabModule
+
+
+class FakeResponse(StringIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+
+def test_update_environment(app, monkeypatch):
+    module = LabModule(core=types.SimpleNamespace(_speak=lambda *a: None))
+
+    data = {"temperature": 21.0, "humidity": 50, "pump": False, "gas_alert": False}
+    resp = FakeResponse(json.dumps(data))
+    monkeypatch.setattr(request, "urlopen", lambda *a, **k: resp)
+    module._update_environment()
+    assert module.temp_label.text() == "Temp: 21.0\u00B0C"
+    assert module.humid_label.text() == "Humidity: 50%"
+    assert module.pump_button.text() == "Pump OFF"
+
+
+def test_toggle_pump(app, monkeypatch):
+    module = LabModule(core=None)
+    module._pump_state = False
+
+    class Dummy:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    def fake_urlopen(req, timeout=1):
+        assert "state=on" in req.full_url
+        return Dummy()
+
+    monkeypatch.setattr(request, "urlopen", fake_urlopen)
+    module._toggle_pump()
+    assert module._pump_state is True
+


### PR DESCRIPTION
## Summary
- implement simple SQLite helpers in `jarvis_core.database`
- expose database utilities in package init
- add pytest to requirements
- create GitHub Actions workflow to run tests
- write unit tests for ChatGPT, Lab module and database functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865a15712a88328b0b76e8b31bc18d2