### PR TITLE
Resolve circular imports and set up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install eSpeak
+        run: sudo apt-get update && sudo apt-get install -y espeak
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Lint and smoke test
+        run: |
+          python -m py_compile $(git ls-files '*.py')
+          python - <<'PY'
+import jarvis_core
+import jarvis
+print('imports ok')
+PY

--- a/jarvis/__init__.py
+++ b/jarvis/__init__.py
@@ -1,11 +1,5 @@
 """JARVIS assistant package."""
 
-from jarvis_core import JarvisCore, ChatGPTModule
-from .gui import JarvisGUI
-from .lab import LabModule
-from .server import app as ServerApp
-from .data import DataManager
-
 __all__ = [
     "JarvisCore",
     "JarvisGUI",
@@ -14,4 +8,33 @@ __all__ = [
     "ServerApp",
     "DataManager",
 ]
+
+
+def __getattr__(name: str):
+    """Lazily import modules to avoid circular dependencies."""
+    if name == "JarvisCore":
+        from jarvis_core import JarvisCore
+
+        return JarvisCore
+    if name == "ChatGPTModule":
+        from jarvis_core import ChatGPTModule
+
+        return ChatGPTModule
+    if name == "JarvisGUI":
+        from .gui import JarvisGUI
+
+        return JarvisGUI
+    if name == "LabModule":
+        from .lab import LabModule
+
+        return LabModule
+    if name == "ServerApp":
+        from .server import app as ServerApp
+
+        return ServerApp
+    if name == "DataManager":
+        from .data import DataManager
+
+        return DataManager
+    raise AttributeError(name)
 

--- a/jarvis_core/core.py
+++ b/jarvis_core/core.py
@@ -6,7 +6,6 @@ from threading import Thread
 from typing import Callable, Optional
 from vosk import Model, KaldiRecognizer
 
-from jarvis.data import DataManager
 from .chatgpt import ChatGPTModule
 
 
@@ -24,6 +23,8 @@ class JarvisCore:
         self.listening = False
         self.log_callback = log_callback
         self.speech_detected_callback = speech_detected_callback
+
+        from jarvis.data import DataManager
 
         DataManager.init_db()
 
@@ -84,6 +85,8 @@ class JarvisCore:
         command = command.lower()
         if self.log_callback:
             self.log_callback(f"User: {command}")
+        from jarvis.data import DataManager
+
         DataManager.log_conversation("user", command)
         if "shutdown" in command:
             reply = "Shutting down. Goodbye, sir."


### PR DESCRIPTION
## Summary
- avoid eager imports in `jarvis.__init__` so the package loads lazily
- dynamically import `DataManager` in `jarvis_core.core`
- add CI workflow installing eSpeak and running a smoke test

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import jarvis_core
import jarvis
print('imports ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68666d4efd04832885f261b580f6d131