### PR TITLE
Fix pyttsx3 CI dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install eSpeak
-        run: sudo apt-get update && sudo apt-get install -y espeak
+        run: sudo apt-get update && sudo apt-get install -y espeak libespeak1
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Greetings Sir,

This pull request updates the CI workflow to ensure the eSpeak packages required by pyttsx3 are installed. The step now installs both `espeak` and `libespeak1` so text-to-speech works correctly during CI runs.


------
https://chatgpt.com/codex/tasks/task_e_686694d8c6808328bff8d6086269d32a